### PR TITLE
Align navigation colors with brand and clean unused CSS

### DIFF
--- a/styles/content.css
+++ b/styles/content.css
@@ -26,36 +26,11 @@
   object-fit: cover;
 }
 
-/* Flexbox 演示容器与子项 */
-.flex-demo {
-  display: flex;
-  gap: 12px;
-  min-height: 120px;
-  background: #f8f9fa;
-}
-.flex-demo .item {
-  background: #e9ecef;
-  border: 2px solid #ced4da;
-  border-radius: .5rem;
-  padding: 12px 16px;
-  min-width: 60px;
-  text-align: center;
-  font-weight: 600;
-}
-
-
-/* XSS 演示区 */
-#unsafe-display, #safe-display {
-  min-height: 48px;
-  background: #fff;
-}
-
-/* 小屏优化 */
-@media (max-width: 576px) {
-  .flex-demo {
-    flex-direction: row;   /* 关键：保持横向，主轴对齐才有可分配空间 */
-    flex-wrap: wrap;       /* 可选：防止极窄屏溢出 */
-  }
+/* 导航链接字体颜色与品牌一致 */
+.navbar-nav .nav-link,
+.navbar-nav .nav-link:hover,
+.navbar-nav .nav-link:focus {
+  color: var(--bs-navbar-brand-color) !important;
 }
 
 


### PR DESCRIPTION
## Summary
- Make navigation links use the same font color as the site brand.
- Remove unused Flexbox and XSS demo styles from content stylesheet.

## Testing
- `python -m py_compile scripts/build_articles.py`
- `node --check scripts/script.js`


------
https://chatgpt.com/codex/tasks/task_b_68b0362cab10832e9972b8f73fdab3ce